### PR TITLE
Enabling instantiation of child class

### DIFF
--- a/src/UserCollectableAttribute.js
+++ b/src/UserCollectableAttribute.js
@@ -57,7 +57,7 @@ class UserColectableAttribute {
       }
       const ucaValue = _.mapValues(_.keyBy(_.map(value, (v, k) => {
         const propertyDef = _.find(definition.type.properties, { name: k });
-        const uca = new UserColectableAttribute(propertyDef.type, v, propertyDef.version);
+        const uca = new this.constructor(propertyDef.type, v, propertyDef.version);
         return { key: k, value: uca };
       }), 'key'), 'value');
       this.value = ucaValue;


### PR DESCRIPTION
When a UCA has inner values (other UCA's) it should instantiate a class that is itself or a subclass of it. E.g.: Claim from credential-commons.