### PR TITLE
Must throw error when it does not find by an identifier and a wrong version

### DIFF
--- a/__test__/UserCollectableAttributes.test.js
+++ b/__test__/UserCollectableAttributes.test.js
@@ -2,7 +2,7 @@ const UCA = require('../src/UserCollectableAttribute');
 const ucaIndex = require('../src');
 
 describe('UCA Constructions tests', () => {
-  test('UCA construction should fails', () => {
+  test('UCA construction for wrong identifier should fails', () => {
     function createUCA() {
       return new UCA('name.first', 'joao');
     }
@@ -257,5 +257,22 @@ describe('UCA Constructions tests', () => {
         `UserCollectableAttribute must not receive attestable value: ${JSON.stringify(attestableValue)}`,
       );
     }
+  });
+
+  test('Must throw error when it does not find UCA by its identifier and version', () => {
+    const identifier = 'cvc:Contact:phoneNumber';
+    const badVersion = '1123414';
+
+    function createUCA() {
+      return new UCA(identifier, {
+        country: 'DE',
+        countryCode: '49',
+        number: '17225252255',
+        lineType: 'mobile',
+        extension: '111',
+      }, badVersion);
+    }
+
+    expect(createUCA).toThrowError(`Version ${badVersion} is not supported for the identifier ${identifier}`);
   });
 });

--- a/src/UserCollectableAttribute.js
+++ b/src/UserCollectableAttribute.js
@@ -7,6 +7,17 @@ const validIdentifiers = _.map(definitions, d => d.identifier);
 
 const isAttestableValue = value => (value && value.attestableValue);
 
+const handleNotFoundDefinition = (identifier, version) => {
+  if (version != null) {
+    const definition = _.find(definitions, { identifier });
+    if (definition) {
+      throw new Error(`Version ${version} is not supported for the identifier ${identifier}`);
+    }
+  }
+
+  throw new Error(`${identifier} is not defined`);
+};
+
 /**
  * Creates new UCA instances
  * @param {*} identifier
@@ -25,11 +36,10 @@ class UserColectableAttribute {
   }
 
   initialize(identifier, value, version) {
-    if (!_.includes(validIdentifiers, identifier)) {
-      throw new Error(`${identifier} is not defined`);
-    }
-
     const definition = version ? _.find(definitions, { identifier, version }) : _.find(definitions, { identifier });
+    if (!definition) {
+      return handleNotFoundDefinition(identifier, version);
+    }
 
     this.timestamp = null;
     this.id = null;
@@ -63,6 +73,7 @@ class UserColectableAttribute {
       this.value = ucaValue;
     }
     this.id = `${this.version}:${this.identifier}:${uuidv4()}`;
+    return this;
   }
 
   initializeAttestableValue() {


### PR DESCRIPTION
In the UCA constructor, a lookup is performed based on name + version. If the version is bad, the definition won't exist, and this causes errors later in lines that need the definition to exist. 
In this code change, the library is throwing the error: 
``Version ${badVersion} is not supported for the identifier ${identifier}``