### PR TITLE
Removing auto version bumping - it was versioning only patch number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+-rc.*$/
+              only: /^v\d+\.\d+\.\d+-release.*$/
             branches:
               ignore: /.*/
       - release_rc:
@@ -25,7 +25,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+-rc.*$/
+              only: /^v\d+\.\d+\.\d+-release.*$/
             branches:
               ignore: /.*/
   deploy-npm:
@@ -106,10 +106,6 @@ jobs:
             git config user.email "no-reply@civic.com"
             git config user.name "CI Deployer"
             git config --global push.default simple
-
-      - run:
-          name: version
-          command: npm version patch --git-tag-version false
 
       - run:
           name: tag

--- a/README.md
+++ b/README.md
@@ -414,13 +414,13 @@ This is used on this library on src/services/config.js
 
 ## Releases
 
-The release process is fully automated and started by Civic members when it's created a tag on Github following the pattern vX.X.X-rcX. E.g.: v0.2.29-rc1.
+The release process is fully automated and started by Civic members when it's created a tag on Github following the pattern vX.X.X-releaseX. E.g.: v0.2.29-release1.
 
 After the creation of the tag, Circle Ci will trigger a job to:
 
 build source files
 run unit tests
 increase version number on package.json
-create the stable version tag dropping the 'rc' suffix. E.g: v0.2.29
+create the stable version tag dropping the 'release' suffix. E.g: v0.2.29
 deploy the binary file to NPM
 


### PR DESCRIPTION
The automated release process was bumping patch versions every time a version was launched.
This is a problem when we need to launch major or minor releases.
This PR removes this automated patch bumping and also enables a release to be triggered by tags that follow the pattern vX.X.X-releaseX. E.g.: v0.2.29-release1.