### PR TITLE
Deleting release tag after the deployment to NPM is done

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,11 @@ jobs:
 
       - run:
           name: tag
-          command: npm run tag  
+          command: npm run tag
+
+      - run:
+        name: delete-release-tag
+        command: git push --delete origin $CIRCLE_TAG
   deploy:
     <<: *defaults  
     steps:


### PR DESCRIPTION
The release process is triggered by the creation of a release tag that following the pattern 'vX.X.X-release.X. Ex.: 'v1.0.0-release.1'.
After the process is done this tag is not needed anymore because another one will be created by CI.

