### PR TITLE
Adding Social Security Number UCA

### DIFF
--- a/__test__/UserCollectableAttributes.test.js
+++ b/__test__/UserCollectableAttributes.test.js
@@ -177,7 +177,7 @@ describe('UCA Constructions tests', () => {
     expect(v.value).toBe('Joao');
   });
 
-  test('Construct IdentityName must result successfuly', () => {
+  test('Construct IdentityName must result successfully', () => {
     const value = { givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' };
     const v = new UCA.IdentityName(value);
     expect(v).toBeDefined();
@@ -316,5 +316,64 @@ describe('UCA Constructions tests', () => {
     }
 
     expect(createUCA).toThrowError(`Version ${badVersion} is not supported for the identifier ${identifier}`);
+  });
+
+  test('Construct cvc:SSN:number successfully', () => {
+    const identifier = 'cvc:SSN:number';
+    const ssn = new UCA(identifier, '123456789');
+
+    const plain = ssn.getPlainValue();
+    expect(plain).toBe('123456789');
+  });
+
+  test('Must throw error for invalid SSN', () => {
+    const identifier = 'cvc:SSN:number';
+
+    function createUCA(id, value) {
+      return new UCA(id, value);
+    }
+
+    expect(createUCA.bind(this, identifier, '12345678'))
+      .toThrowError(`${JSON.stringify('12345678')} is not valid for ${identifier}`);
+
+    expect(createUCA.bind(this, identifier, 'abc123456'))
+      .toThrowError(`${JSON.stringify('abc123456')} is not valid for ${identifier}`);
+
+    expect(createUCA.bind(this, identifier, 'abcdefghi'))
+      .toThrowError(`${JSON.stringify('abcdefghi')} is not valid for ${identifier}`);
+
+    expect(createUCA.bind(this, identifier, 'abcde'))
+      .toThrowError(`${JSON.stringify('abcde')} is not valid for ${identifier}`);
+  });
+
+  test('Construct cvc:SSN:serialNumber', () => {
+    const identifier = 'cvc:SSN:serialNumber';
+    const ssn = new UCA(identifier, '1234');
+
+    const plain = ssn.getPlainValue();
+    expect(plain).toBe('1234');
+  });
+
+  test('Must throw error for invalid cvc:SSN:serialNumber', () => {
+    const identifier = 'cvc:SSN:serialNumber';
+
+    function createUCA(id, value) {
+      return new UCA(id, value);
+    }
+
+    expect(createUCA.bind(this, identifier, '123'))
+      .toThrowError(`${JSON.stringify('123')} is not valid for ${identifier}`);
+
+    expect(createUCA.bind(this, identifier, '12345'))
+      .toThrowError(`${JSON.stringify('12345')} is not valid for ${identifier}`);
+
+    expect(createUCA.bind(this, identifier, 'abc'))
+      .toThrowError(`${JSON.stringify('abc')} is not valid for ${identifier}`);
+
+    expect(createUCA.bind(this, identifier, 'abcd'))
+      .toThrowError(`${JSON.stringify('abcd')} is not valid for ${identifier}`);
+
+    expect(createUCA.bind(this, identifier, 'abcde'))
+      .toThrowError(`${JSON.stringify('abcde')} is not valid for ${identifier}`);
   });
 });

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -625,6 +625,20 @@ const definitions = [
     type: 'String',
     credentialItem: true,
   },
+  {
+    identifier: 'cvc:SSN:number',
+    version: '1',
+    type: 'String',
+    pattern: /^\d{9}$/,
+    credentialItem: true,
+  },
+  {
+    identifier: 'cvc:SSN:serialNumber',
+    version: '1',
+    type: 'String',
+    pattern: /^\d{4}$/,
+    credentialItem: true,
+  },
 ];
 
 module.exports = definitions;


### PR DESCRIPTION
Adding the Social Security Number (SSN) UCA to the Library:

- SSN UCA: Collects a 9 digit SSN

- SSN4 (serial number): UCA of the last 4 digits of an SSN.

This new UCA is following this definition:
https://www.ssa.gov/history/ssn/geocard.html