### PR TITLE
Exposing credentialItem attribute

### DIFF
--- a/__test__/UserCollectableAttributes.test.js
+++ b/__test__/UserCollectableAttributes.test.js
@@ -367,7 +367,6 @@ describe('UCA Constructions tests', () => {
   test('Construct cvc:SocialSecurity:serialNumber', () => {
     const identifier = 'cvc:SocialSecurity:serialNumber';
     const ssn = new UCA(identifier, '1234');
-
     const plain = ssn.getPlainValue();
     expect(plain).toBe('1234');
   });
@@ -393,5 +392,13 @@ describe('UCA Constructions tests', () => {
 
     expect(createUCA.bind(this, identifier, 'abcde'))
       .toThrowError(`${JSON.stringify('abcde')} is not valid for ${identifier}`);
+  });
+
+  test('Check credentialItem attribute', () => {
+    const uca = new UCA('cvc:Name:givenNames', 'Yan');
+    expect(uca.credentialItem).toBeTruthy();
+
+    const uca2 = new UCA('cvc:Meta:expirationDate', '-1');
+    expect(uca2.credentialItem).toBeFalsy();
   });
 });

--- a/src/UserCollectableAttribute.js
+++ b/src/UserCollectableAttribute.js
@@ -21,6 +21,7 @@ class UserCollectableAttribute {
     this.version = null;
     this.type = null;
     this.value = null;
+    this.credentialItem = null;
     this.definitions = customDefinitions || definitions;
 
     this.initialize(identifier, value, version);
@@ -65,6 +66,8 @@ class UserCollectableAttribute {
       }), 'key'), 'value');
       this.value = ucaValue;
     }
+
+    this.credentialItem = definition.credentialItem;
     this.id = `${this.version}:${this.identifier}:${uuidv4()}`;
     return this;
   }
@@ -94,10 +97,7 @@ class UserCollectableAttribute {
         if (propName) {
           newParent[propName] = this.value;
         } else {
-          if (!this.credentialItem) {
-            return this.value;
-          }
-          newParent[this.identifier] = this.value;
+          return this.value;
         }
         return newParent;
       default:


### PR DESCRIPTION
In order to convert UCA to credential-commons/Claim must be a way to check if a UCA can be converted.
This is exposed by the `credentialItem` attribute.