### PR TITLE
Improve release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ workflows:
               only: /^v\d+\.\d+\.\d+-release.*$/
             branches:
               ignore: /.*/
-      - release_rc:
+      - release:
           context: Production
           requires:
             - build
@@ -75,8 +75,11 @@ jobs:
           root: ~/repo
           paths: .
 
-  release_rc:
+  release:
     <<: *defaults
+    environment:
+      HUB_ARTIFACT_VERSION: 2.5.1
+      HUB_ARTIFACT: hub-linux-amd64-2.5.1
     steps:
       - checkout
 
@@ -114,8 +117,16 @@ jobs:
       - run:
           name: delete-release-tag
           command: git push --delete origin $CIRCLE_TAG
+
+      - run: |
+          sh ./.circleci/install_hub.sh
+          mkdir ~/.config/ && echo -e "github.com:\n- user: civictechuser\n  oauth_token: $GITHUB_API_KEY\n  protocol: https\n" > ~/.config/hub
+      
+      - run: |
+          hub release delete $CIRCLE_TAG
+
   deploy:
-    <<: *defaults  
+    <<: *defaults
     steps:
       - attach_workspace:
           at: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+-release.*$/
+              only: /^release\..*$/
             branches:
               ignore: /.*/
       - release:
@@ -25,7 +25,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+-release.*$/
+              only: /^release\..*$/
             branches:
               ignore: /.*/
   deploy-npm:

--- a/.circleci/install_hub.sh
+++ b/.circleci/install_hub.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+mkdir -p .hub_tmp
+cd .hub_tmp
+
+if [ ! -f "$HUB_ARTIFACT.tgz" ]; then
+    wget https://github.com/github/hub/releases/download/v$HUB_ARTIFACT_VERSION/$HUB_ARTIFACT.tgz
+fi
+
+tar -xvzf $HUB_ARTIFACT.tgz
+sudo ./$HUB_ARTIFACT/install
+
+rm -rf ./$HUB_ARTIFACT

--- a/README.md
+++ b/README.md
@@ -414,13 +414,14 @@ This is used on this library on src/services/config.js
 
 ## Releases
 
-The release process is fully automated and started by Civic members when it's created a tag on Github following the pattern vX.X.X-releaseX. E.g.: v0.2.29-release1.
+The release process is fully automated and started by Civic members when it's created a tag on Github following the pattern ^release\\..*$. E.g.: `release.1`.
 
 After the creation of the tag, Circle Ci will trigger a job to:
 
 build source files
 run unit tests
 increase version number on package.json
-create the stable version tag dropping the 'release' suffix. E.g: v0.2.29
+create the stable version and tag it. E.g: v0.2.29
+remove the release.N tag
 deploy the binary file to NPM
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "build": "npm run build:browser && npm run build:cjs && npm run build:es",
     "tag": "git tag v$npm_package_version && git push --tags origin master",
     "pretag": "git fetch --tags",
-    "precommit": "npm run lint",
-    "postversion": "git checkout master && git add --all && git commit -m\"build and version $npm_package_version\" -m\"[skip ci]\" && git push origin master"
+    "precommit": "npm run lint"
   },
   "author": "Identity.com Community",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Provides functionality around User Collectable Attributes (UCA)",
   "main": "src/index.js",
   "module": "dist/es/index.js",


### PR DESCRIPTION
- Removing the 'Github release' that is created to trigger the release process
- Removing `postversion` hook because versions are now manually defined
- Triggering release process when a tag following the pattern '^release\..*$' is created