### PR TITLE
Rename S3FileRef properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Provides functionality around User Collectable Attributes (UCA)",
   "main": "src/index.js",
   "module": "dist/es/index.js",

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -506,11 +506,11 @@ const definitions = [
     type: {
       properties: [
         {
-          name: 'Bucket',
+          name: 's3FileBucket',
           type: 'cvc:Type:s3FileBucket',
         },
         {
-          name: 'Key',
+          name: 's3FileKey',
           type: 'cvc:Type:s3FileKey',
         },
         {
@@ -522,7 +522,7 @@ const definitions = [
           type: 'cvc:Type:ContentType',
         },
       ],
-      required: ['Bucket', 'Key', 'MD5', 'ContentType'],
+      required: ['s3FileBucket', 's3FileKey', 'MD5', 'ContentType'],
     },
   },
   {


### PR DESCRIPTION
Update `S3FileRef` properties name to make type and name the same.

Update UCA version to `1.0.3`. 