### PR TITLE
Fix missing parameter for custom definitions in UCA construction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Provides functionality around User Collectable Attributes (UCA)",
   "main": "src/index.js",
   "module": "dist/es/index.js",

--- a/src/UserCollectableAttribute.js
+++ b/src/UserCollectableAttribute.js
@@ -90,7 +90,7 @@ class UserCollectableAttribute {
   }
 
   initialize(identifier, value, version) {
-    const definition = UserCollectableAttribute.getDefinition(identifier, version);
+    const definition = UserCollectableAttribute.getDefinition(identifier, version, this.definitions);
 
     this.timestamp = null;
     this.id = null;


### PR DESCRIPTION
Fix missing parameter for custom definitions in UCA construction and update uca to version `1.0.6`.