### PR TITLE
Features/id 486 evidence support

### DIFF
--- a/__test__/UserCollectableAttributes.test.js
+++ b/__test__/UserCollectableAttributes.test.js
@@ -305,6 +305,46 @@ describe('UCA Constructions tests', () => {
     expect(address.id).toBeDefined();
   });
 
+  test('Construct cvc:Hash:algorithm', () => {
+    const identifier = 'cvc:Hash:algorithm';
+    const hashAlgorithm = new UCA(identifier, 'MD5');
+
+    expect(hashAlgorithm.id).toBeDefined();
+
+    const plain = hashAlgorithm.getPlainValue();
+    expect(plain).toBe('MD5');
+  });
+
+  test('Construct cvc:Type:evidence', () => {
+    const identifier = 'cvc:Type:evidence';
+    const evidence = new UCA(identifier, {
+      algorithm: 'MD5',
+      data: '8e55a2c4a1f018314c1e8d3bead078fb',
+    });
+
+    expect(evidence.id).toBeDefined();
+
+    const plain = evidence.getPlainValue();
+    expect(plain.algorithm).toBe('MD5');
+    expect(plain.data).toBe('8e55a2c4a1f018314c1e8d3bead078fb');
+  });
+
+  test('Construct cvc:Validation:evidences', () => {
+    const identifier = 'cvc:Validation:evidences';
+    const idDocumentFront = { algorithm: 'MD5', data: '8e55a2c4a1f018314c1e8d3bead078fb' };
+    const idDocumentBack = { algorithm: 'MD5', data: 'b698226a9595562690f9121cc6bfa2a1' };
+    const selfie = { algorithm: 'MD5', data: '0c64397149b22323edcdee35e3507b03' };
+
+    const evidences = new UCA(identifier, { idDocumentFront, idDocumentBack, selfie });
+
+    expect(evidences.id).toBeDefined();
+
+    const plain = evidences.getPlainValue();
+    expect(plain.idDocumentFront).toEqual(idDocumentFront);
+    expect(plain.idDocumentBack).toEqual(idDocumentBack);
+    expect(plain.selfie).toEqual(selfie);
+  });
+
   test('Should get ALL UCA properties email', () => {
     const properties = UCA.getAllProperties('cvc:Contact:email');
     expect(properties).toHaveLength(3);

--- a/__test__/UserCollectableAttributes.test.js
+++ b/__test__/UserCollectableAttributes.test.js
@@ -307,33 +307,33 @@ describe('UCA Constructions tests', () => {
 
   test('Construct cvc:Hash:algorithm', () => {
     const identifier = 'cvc:Hash:algorithm';
-    const hashAlgorithm = new UCA(identifier, 'MD5');
+    const hashAlgorithm = new UCA(identifier, 'md5');
 
     expect(hashAlgorithm.id).toBeDefined();
 
     const plain = hashAlgorithm.getPlainValue();
-    expect(plain).toBe('MD5');
+    expect(plain).toBe('md5');
   });
 
   test('Construct cvc:Type:evidence', () => {
     const identifier = 'cvc:Type:evidence';
     const evidence = new UCA(identifier, {
-      algorithm: 'MD5',
+      algorithm: 'md5',
       data: '8e55a2c4a1f018314c1e8d3bead078fb',
     });
 
     expect(evidence.id).toBeDefined();
 
     const plain = evidence.getPlainValue();
-    expect(plain.algorithm).toBe('MD5');
+    expect(plain.algorithm).toBe('md5');
     expect(plain.data).toBe('8e55a2c4a1f018314c1e8d3bead078fb');
   });
 
   test('Construct cvc:Validation:evidences', () => {
     const identifier = 'cvc:Validation:evidences';
-    const idDocumentFront = { algorithm: 'MD5', data: '8e55a2c4a1f018314c1e8d3bead078fb' };
-    const idDocumentBack = { algorithm: 'MD5', data: 'b698226a9595562690f9121cc6bfa2a1' };
-    const selfie = { algorithm: 'MD5', data: '0c64397149b22323edcdee35e3507b03' };
+    const idDocumentFront = { algorithm: 'md5', data: '8e55a2c4a1f018314c1e8d3bead078fb' };
+    const idDocumentBack = { algorithm: 'md5', data: 'b698226a9595562690f9121cc6bfa2a1' };
+    const selfie = { algorithm: 'md5', data: '0c64397149b22323edcdee35e3507b03' };
 
     const evidences = new UCA(identifier, { idDocumentFront, idDocumentBack, selfie });
 

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -266,8 +266,8 @@ const definitions = [
     version: '1',
     type: 'String',
     enum: {
-      SHA256: 'SHA256',
-      MD5: 'MD5',
+      SHA256: 'sha256',
+      MD5: 'md5',
     },
   },
   {

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -273,7 +273,7 @@ const definitions = [
   {
     identifier: 'cvc:Hash:data',
     version: '1',
-    type: 'string',
+    type: 'String',
   },
   {
     identifier: 'cvc:Type:evidence',

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -264,7 +264,7 @@ const definitions = [
   {
     identifier: 'cvc:Hash:algorithm',
     version: '1',
-    type: 'string',
+    type: 'String',
     enum: {
       SHA256: 'SHA256',
       MD5: 'MD5',

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -305,8 +305,7 @@ const definitions = [
       {
         name: 'selfie',
         type: 'cvc:Type:evidence',
-      }],
-      required: ['day', 'month', 'year'],
+      }]
     },
   },
   {

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -262,6 +262,54 @@ const definitions = [
     credentialItem: false,
   },
   {
+    identifier: 'cvc:Hash:algorithm',
+    version: '1',
+    type: 'string',
+    enum: {
+      SHA256: 'SHA256',
+      MD5: 'MD5',
+    },
+  },
+  {
+    identifier: 'cvc:Hash:data',
+    version: '1',
+    type: 'string',
+  },
+  {
+    identifier: 'cvc:Type:evidence',
+    type: {
+      properties: [
+        {
+          name: 'algorithm',
+          type: 'cvc:Hash:algorithm',
+        },
+        {
+          name: 'data',
+          type: 'cvc:Hash:data',
+        },
+      ],
+      required: ['algorithm', 'data'],
+    },
+  },
+  {
+    identifier: 'cvc:Validation:evidences',
+    type: {
+      properties: [{
+        name: 'idDocumentFront',
+        type: 'cvc:Type:evidence',
+      },
+      {
+        name: 'idDocumentBack',
+        type: 'cvc:Type:evidence',
+      },
+      {
+        name: 'selfie',
+        type: 'cvc:Type:evidence',
+      }],
+      required: ['day', 'month', 'year'],
+    },
+  },
+  {
     identifier: 'cvc:Identity:name',
     version: '1',
     type: 'cvc:Type:Name',
@@ -502,6 +550,31 @@ const definitions = [
   },
   {
     identifier: 'cvc:Type:S3FileRef',
+    version: '1',
+    type: {
+      properties: [
+        {
+          name: 's3FileBucket',
+          type: 'cvc:Type:s3FileBucket',
+        },
+        {
+          name: 's3FileKey',
+          type: 'cvc:Type:s3FileKey',
+        },
+        {
+          name: 'MD5',
+          type: 'cvc:Type:MD5',
+        },
+        {
+          name: 'ContentType',
+          type: 'cvc:Type:ContentType',
+        },
+      ],
+      required: ['s3FileBucket', 's3FileKey', 'MD5', 'ContentType'],
+    },
+  },
+  {
+    identifier: 'cvc:S3Ref:selfie',
     version: '1',
     type: {
       properties: [

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -292,19 +292,31 @@ const definitions = [
     },
   },
   {
+    identifier: 'cvc:Type:idDocumentFront',
+    type: 'cvc:Type:evidence',
+  },
+  {
+    identifier: 'cvc:Type:idDocumentBack',
+    type: 'cvc:Type:evidence',
+  },
+  {
+    identifier: 'cvc:Type:selfie',
+    type: 'cvc:Type:evidence',
+  },
+  {
     identifier: 'cvc:Validation:evidences',
     type: {
       properties: [{
         name: 'idDocumentFront',
-        type: 'cvc:Type:evidence',
+        type: 'cvc:Type:idDocumentFront',
       },
       {
         name: 'idDocumentBack',
-        type: 'cvc:Type:evidence',
+        type: 'cvc:Type:idDocumentBack',
       },
       {
         name: 'selfie',
-        type: 'cvc:Type:evidence',
+        type: 'cvc:Type:selfie',
       }],
     },
   },

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -305,7 +305,7 @@ const definitions = [
       {
         name: 'selfie',
         type: 'cvc:Type:evidence',
-      }]
+      }],
     },
   },
   {


### PR DESCRIPTION
Introduce 2 new UCAs:

`cvc:Validation:evidences` with (idDocumentFront, idDocumentBack, selfie) properties of type `cvc:Type:evidence`

and

`cvc:S3Ref:selfie` with (s3FileBucket, s3FileKey, MD5, ContentType) properties deprecating the use of `cvc:Type:S3Fileref`
