### PR TITLE
Fix getFlattenValue to support alias UCAs

### DIFF
--- a/__test__/UserCollectableAttributes.test.js
+++ b/__test__/UserCollectableAttributes.test.js
@@ -679,6 +679,34 @@ describe('UCA Constructions tests', () => {
     });
 
     it('Should flatten structure UCA with ambiguities', () => {
+      const ucaObject = new UCA('cvc:Document:evidences', {
+        idDocumentFront: { algorithm: 'sha256', data: 'sha256(idDocumentFront)' },
+        idDocumentBack: { algorithm: 'sha256', data: 'sha256(idDocumentBack)' },
+        selfie: { algorithm: 'sha256', data: 'sha256(selfie)' },
+      });
+      const flat = ucaObject.getFlattenValue();
+      expect(flat).toBeDefined();
+      expect(flat).toHaveLength(6);
+      const was = [
+        { name: 'cvc:Hash:algorithm', value: 'sha256' },
+        { name: 'cvc:Hash:data', value: 'sha256(idDocumentFront)' },
+        { name: 'cvc:Hash:algorithm', value: 'sha256' },
+        { name: 'cvc:Hash:data', value: 'sha256(idDocumentBack)' },
+        { name: 'cvc:Hash:algorithm', value: 'sha256' },
+        { name: 'cvc:Hash:data', value: 'sha256(selfie)' },
+      ];
+      const expected = [
+        { name: 'cvc:Hash:algorithm>idDocumentFront', value: 'sha256' },
+        { name: 'cvc:Hash:data>idDocumentFront', value: 'sha256(idDocumentFront)' },
+        { name: 'cvc:Hash:algorithm>idDocumentBack', value: 'sha256' },
+        { name: 'cvc:Hash:data>idDocumentBack', value: 'sha256(idDocumentBack)' },
+        { name: 'cvc:Hash:algorithm>selfie', value: 'sha256' },
+        { name: 'cvc:Hash:data>selfie', value: 'sha256(selfie)' }];
+      expect(flat).toEqual(expect.arrayContaining(expected));
+      expect(flat).not.toEqual(expect.arrayContaining(was));
+    });
+
+    it('Should flatten an alias to a structure UCA with ambiguities', () => {
       const ucaObject = new UCA('cvc:Validation:evidences', {
         idDocumentFront: { algorithm: 'sha256', data: 'sha256(idDocumentFront)' },
         idDocumentBack: { algorithm: 'sha256', data: 'sha256(idDocumentBack)' },
@@ -695,7 +723,6 @@ describe('UCA Constructions tests', () => {
         { name: 'cvc:Hash:algorithm', value: 'sha256' },
         { name: 'cvc:Hash:data', value: 'sha256(selfie)' },
       ];
-
       const expected = [
         { name: 'cvc:Hash:algorithm>idDocumentFront', value: 'sha256' },
         { name: 'cvc:Hash:data>idDocumentFront', value: 'sha256(idDocumentFront)' },
@@ -745,6 +772,20 @@ describe('UCA Constructions tests', () => {
     });
 
     it('Should unflatten structure UCA with ambiguity', () => {
+      const ucaObject = UCA.fromFlattenValue('cvc:Document:evidences',
+        [
+          { name: 'cvc:Hash:algorithm>idDocumentFront', value: 'sha256' },
+          { name: 'cvc:Hash:data>idDocumentFront', value: 'sha256(idDocumentFront)' },
+          { name: 'cvc:Hash:algorithm>idDocumentBack', value: 'sha256' },
+          { name: 'cvc:Hash:data>idDocumentBack', value: 'sha256(idDocumentBack)' },
+          { name: 'cvc:Hash:algorithm>selfie', value: 'sha256' },
+          { name: 'cvc:Hash:data>selfie', value: 'sha256(selfie)' },
+        ]);
+      expect(ucaObject).toBeDefined();
+      expect(ucaObject.identifier).toBe('cvc:Document:evidences');
+    });
+
+    it('Should unflatten an alias for a structure UCA with ambiguity', () => {
       const ucaObject = UCA.fromFlattenValue('cvc:Validation:evidences',
         [
           { name: 'cvc:Hash:algorithm>idDocumentFront', value: 'sha256' },
@@ -752,7 +793,8 @@ describe('UCA Constructions tests', () => {
           { name: 'cvc:Hash:algorithm>idDocumentBack', value: 'sha256' },
           { name: 'cvc:Hash:data>idDocumentBack', value: 'sha256(idDocumentBack)' },
           { name: 'cvc:Hash:algorithm>selfie', value: 'sha256' },
-          { name: 'cvc:Hash:data>selfie', value: 'sha256(selfie)' }]);
+          { name: 'cvc:Hash:data>selfie', value: 'sha256(selfie)' },
+        ]);
       expect(ucaObject).toBeDefined();
       expect(ucaObject.identifier).toBe('cvc:Validation:evidences');
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Provides functionality around User Collectable Attributes (UCA)",
   "main": "src/index.js",
   "module": "dist/es/index.js",

--- a/src/UserCollectableAttribute.js
+++ b/src/UserCollectableAttribute.js
@@ -183,8 +183,10 @@ class UserCollectableAttribute {
   getFlattenValue(acumulator = [], sufix = null) {
     if (this.type === 'Object') {
       const definition = UserCollectableAttribute.getDefinition(this.identifier, this.version);
+      const resolvedType = resolveType(definition, this.definitions);
+
       _.each(_.keys(this.value), (key) => {
-        const deambiguify = _.get(_.find(definition.type.properties, { name: key }), 'deambiguify');
+        const deambiguify = _.get(_.find(resolvedType.properties, { name: key }), 'deambiguify');
         this.value[key].getFlattenValue(acumulator, deambiguify ? `>${key}` : sufix);
       });
     } else {

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -309,7 +309,7 @@ const definitions = [
     type: 'cvc:Type:evidence',
   },
   {
-    identifier: 'cvc:Validation:evidences',
+    identifier: 'cvc:Document:evidences',
     version: '1',
     type: {
       properties: [{
@@ -328,6 +328,13 @@ const definitions = [
         deambiguify: true,
       }],
     },
+    credentialItem: true,
+  },
+  {
+    identifier: 'cvc:Validation:evidences',
+    version: '1',
+    type: 'cvc:Document:evidences',
+    alias: true,
     credentialItem: true,
   },
   {

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -334,7 +334,6 @@ const definitions = [
     identifier: 'cvc:Validation:evidences',
     version: '1',
     type: 'cvc:Document:evidences',
-    alias: true,
     credentialItem: true,
   },
   {


### PR DESCRIPTION
Fix `getFlattenValue` to support alias UCAs.

An "alias UCA" is a UCA which type is another UCA identifier.

This PR renames `cvc:Validation:evidences` to `cvc:Document:evidences` and creates `cvc:Validation:evidences` as an alias, as following:
```
  {
    identifier: 'cvc:Validation:evidences',
    version: '1',
    type: 'cvc:Document:evidences',
    credentialItem: true,
  }
```