### PR TITLE
Support alias definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Provides functionality around User Collectable Attributes (UCA)",
   "main": "src/index.js",
   "module": "dist/es/index.js",

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -334,6 +334,7 @@ const definitions = [
     identifier: 'cvc:Validation:evidences',
     version: '1',
     type: 'cvc:Document:evidences',
+    alias: true,
     credentialItem: true,
   },
   {


### PR DESCRIPTION
Add `alias` flag to `cvc:Validation:evidences` UCA.

Bump version to 1.0.13.