### PR TITLE
Array support

### DIFF
--- a/__test__/UserCollectableAttributesWithMockedDefinitions.test.js
+++ b/__test__/UserCollectableAttributesWithMockedDefinitions.test.js
@@ -67,6 +67,21 @@ describe('UCA Constructions tests', () => {
     ];
     const uca = new UCA(identifier, value);
     expect(uca).toBeDefined();
+    expect(uca.getPlainValue()).toBeDefined();
+  });
+
+  test('Should construct UCA with a property of type array', () => {
+    const identifier = 'cvc:Uca:withCollection';
+    const value = {
+      collection: [
+        'Belo Horizonte',
+        'Brazil',
+        'Minas Gerais',
+      ],
+    };
+    const uca = new UCA(identifier, value);
+    expect(uca).toBeDefined();
+    expect(uca.getPlainValue()).toBeDefined();
   });
 
   test('Should apply constraints when constructing UCA from another UCA type', () => {

--- a/__test__/UserCollectableAttributesWithMockedDefinitions.test.js
+++ b/__test__/UserCollectableAttributesWithMockedDefinitions.test.js
@@ -83,6 +83,17 @@ describe('UCA Constructions tests', () => {
     expect(uca).toBeDefined();
     expect(uca.getPlainValue()).toBeDefined();
   });
+  test('Should construct UCA with array of objects', () => {
+    const identifier = 'cvc:Collection.objects';
+    const value = [
+      { day: 20, month: 3, year: 1978 },
+      { day: 20, month: 5, year: 1978 },
+      { day: 20, month: 7, year: 1978 },
+    ];
+    const uca = new UCA(identifier, value);
+    expect(uca).toBeDefined();
+    expect(uca.getPlainValue()).toBeDefined();
+  });
 
   test('Should apply constraints when constructing UCA from another UCA type', () => {
     const identifier = 'cvc:Verify:phoneNumberToken';

--- a/__test__/UserCollectableAttributesWithMockedDefinitions.test.js
+++ b/__test__/UserCollectableAttributesWithMockedDefinitions.test.js
@@ -58,6 +58,17 @@ describe('UCA Constructions tests', () => {
     expect(uca).toBeDefined();
   });
 
+  test('Should construct UCA with array', () => {
+    const identifier = 'cvc:Collection.records';
+    const value = [
+      'Belo Horizonte',
+      'Brazil',
+      'Minas Gerais',
+    ];
+    const uca = new UCA(identifier, value);
+    expect(uca).toBeDefined();
+  });
+
   test('Should apply constraints when constructing UCA from another UCA type', () => {
     const identifier = 'cvc:Verify:phoneNumberToken';
     const value = 'incorrect-format-token';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2504,7 +2504,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -8145,7 +8146,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -8558,7 +8560,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 93,
+        "branches": 92,
         "functions": 100,
         "lines": 98,
         "statements": 98

--- a/src/UserCollectableAttribute.js
+++ b/src/UserCollectableAttribute.js
@@ -14,7 +14,7 @@ const {
 } = require('./utils');
 const { UCATemplateValue } = require('./UCATemplateValue');
 
-const isAttestableValue = value => (value && value.attestableValue);
+const isAttestableValue = (value) => (value && value.attestableValue);
 
 const handleNotFoundDefinition = (myDefinitions, identifier, version) => {
   if (version != null) {
@@ -165,7 +165,7 @@ class UserCollectableAttribute {
       const name = nameComponents[0];
       const sufix = nameComponents[1];
       const property = _.find(meta.properties,
-        o => o.name === name && (!sufix || _.includes(o.meta.propertyName, sufix)));
+        (o) => o.name === name && (!sufix || _.includes(o.meta.propertyName, sufix)));
 
       if (_.get(property, 'meta.type') === 'Number') {
         fixedValue.value = _.toNumber(item.value);
@@ -260,7 +260,7 @@ class UserCollectableAttribute {
           const typeSuffix = _.split(prop.type, ':')[2];
           const newBasePropName = prop.name === typeSuffix ? basePropName : `${basePropName}.${prop.name}`;
           const proProperties = UserCollectableAttribute.getAllProperties(prop.type, newBasePropName);
-          _.forEach(proProperties, p => properties.push(p));
+          _.forEach(proProperties, (p) => properties.push(p));
         });
       }
     } else if (pathName) {
@@ -353,7 +353,7 @@ function convertIdentifierToClassName(identifier) {
 
 function mixinIdentifiers(UCA) {
   // Extend UCA Semantic
-  _.forEach(_.filter(definitions, d => d.credentialItem), (def) => {
+  _.forEach(_.filter(definitions, (d) => d.credentialItem), (def) => {
     const name = convertIdentifierToClassName(def.identifier);
     const source = {};
     const { identifier } = def;

--- a/src/UserCollectableAttribute.js
+++ b/src/UserCollectableAttribute.js
@@ -117,14 +117,9 @@ class UserCollectableAttribute {
   initializeValuesWithArrayItems(identifier, values, version) {
     const definition = UserCollectableAttribute.getDefinition(identifier, version, this.definitions);
 
-    const ucaArray = [];
-
     if (!_.isArray(values)) throw new Error(`Value for ${identifier}-${version} should be an array`);
 
-    _.forEach(values, (value) => {
-      const uca = new UserCollectableAttribute(_.get(definition, 'items.type'), value);
-      ucaArray.push(uca);
-    });
+    const ucaArray = _.map(values, (value) => new UserCollectableAttribute(_.get(definition, 'items.type'), value));
 
     this.value = ucaArray;
   }

--- a/src/__mocks__/definitions.js
+++ b/src/__mocks__/definitions.js
@@ -666,6 +666,20 @@ const definitions = [
     },
     credentialItem: true,
   },
+  {
+    identifier: 'cvc:Uca:withCollection',
+    version: '1',
+    attestable: true,
+    type: {
+      properties: [
+        {
+          name: 'collection',
+          type: 'cvc:Collection.records',
+        },
+      ],
+      required: ['collection'],
+    },
+  },
 ];
 
 module.exports = definitions;

--- a/src/__mocks__/definitions.js
+++ b/src/__mocks__/definitions.js
@@ -657,6 +657,15 @@ const definitions = [
     type: 'String',
     credentialItem: true,
   },
+  {
+    identifier: 'cvc:Collection.records',
+    version: '1',
+    type: 'Array',
+    items: {
+      type: 'cvc:Document:placeOfBirth',
+    },
+    credentialItem: true,
+  },
 ];
 
 module.exports = definitions;

--- a/src/__mocks__/definitions.js
+++ b/src/__mocks__/definitions.js
@@ -667,6 +667,15 @@ const definitions = [
     credentialItem: true,
   },
   {
+    identifier: 'cvc:Collection.objects',
+    version: '1',
+    type: 'Array',
+    items: {
+      type: 'cvc:Document:dateOfBirth',
+    },
+    credentialItem: true,
+  },
+  {
     identifier: 'cvc:Uca:withCollection',
     version: '1',
     attestable: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const getValidIdentifiers = definitions => _.map(definitions, d => d.identifier);
+const getValidIdentifiers = (definitions) => _.map(definitions, (d) => d.identifier);
 
 /**
  * extract the expected Type name for the value when constructing an UCA
@@ -76,7 +76,7 @@ const getObjectBasePropName = (definitions, typeDefinition, pathName) => {
 };
 
 const flagRequeredProps = (requiredArray, props) => (
-  _.map(props, p => _.merge(p, { required: _.includes(requiredArray, p.name) }))
+  _.map(props, (p) => _.merge(p, { required: _.includes(requiredArray, p.name) }))
 );
 
 const getObjectTypeDefProps = (definitions, typeDefinition) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const getValidIdentifiers = (definitions) => _.map(definitions, (d) => d.identifier);
+const getValidIdentifiers = definitions => _.map(definitions, d => d.identifier);
 
 /**
  * extract the expected Type name for the value when constructing an UCA
@@ -76,7 +76,7 @@ const getObjectBasePropName = (definitions, typeDefinition, pathName) => {
 };
 
 const flagRequeredProps = (requiredArray, props) => (
-  _.map(props, (p) => _.merge(p, { required: _.includes(requiredArray, p.name) }))
+  _.map(props, p => _.merge(p, { required: _.includes(requiredArray, p.name) }))
 );
 
 const getObjectTypeDefProps = (definitions, typeDefinition) => {


### PR DESCRIPTION
Now we can support array structures in the UCA definitions. This is required to support Arrays the the claims definitions too.