### PR TITLE
Add version number to externalServiceAuth UCA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/uca",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Provides functionality around User Collectable Attributes (UCA)",
   "main": "src/index.js",
   "module": "dist/es/index.js",

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -1042,11 +1042,13 @@ const definitions = [
   },
   {
     identifier: 'cvc:Type:hasConnected',
+    version: '1',
     type: 'Boolean',
     credentialItem: false,
   },
   {
     identifier: 'cvc:Type:externalServiceAuth',
+    version: '1',
     type: {
       properties: [
         {


### PR DESCRIPTION
Version number was missing for `externalServiceAuth` and it's property `hasConnected`.